### PR TITLE
DYN-6651-Updating-NETSDK

### DIFF
--- a/IssuesTypePredicterML.ConsoleApp/IssuesTypePredicterML.ConsoleApp.csproj
+++ b/IssuesTypePredicterML.ConsoleApp/IssuesTypePredicterML.ConsoleApp.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>IssuesTypePredicterML</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
@@ -12,7 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="..\IssuesTypePredicterML.Model\IssuesTypePredicterML.Model.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectCapability Include="ModelBuilderGenerated" />
   </ItemGroup>

--- a/IssuesTypePredicterML.Model/IssuesTypePredicterML.Model.csproj
+++ b/IssuesTypePredicterML.Model/IssuesTypePredicterML.Model.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ML" Version="1.5.2" />
     <PackageReference Include="Microsoft.ML.LightGBM" Version="1.5.2" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="MLModel.zip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectCapability Include="ModelBuilderGenerated" />
   </ItemGroup>


### PR DESCRIPTION
Updating NET to .NET 8 so it can be used correctly in the GitHub action due that the current one used .NET Core 3.1.0 and .Net 2.0 is out of support.
https://github.com/dotnet/core/blob/main/os-lifecycle-policy.md